### PR TITLE
[WIP] Utilizing Proxy to handle re-render of components

### DIFF
--- a/index.css
+++ b/index.css
@@ -62,6 +62,11 @@ html, body {
   background: white;
 }
 
+#player-info {
+  color: var(--white);
+  font-size: 1.8rem;
+}
+
 player-menu {
   position: absolute;
   top: 0;
@@ -192,6 +197,7 @@ health-bar {
   height: 15px;
 
   display: block;
+  transition: width .2s;
 
   background: var(--green);
 }

--- a/js/classes/character.js
+++ b/js/classes/character.js
@@ -1,11 +1,19 @@
+import { renderElements } from '../utils/webComponent.js'
+
 export default class Character {
   constructor(name, stats) {
-    this._name = name;
-    this._baseStats = Object.create(stats);
-    this._stats = stats;
-
     this._effects = [];
     this._elements = {}; 
+    this.renderElements = renderElements.bind(this)
+    
+    this._name = name;
+    this._baseStats = Object.create(stats);
+    this._stats = new Proxy(stats, {
+      set: (target, prop, val) => {
+        this.renderElements(prop, val)
+        return Reflect.set(target, prop, val)  
+      }
+    });
   }
 
   get effects() {
@@ -15,10 +23,8 @@ export default class Character {
   damage(pts) {
     if (pts > 0) {
       this._stats.hp -= pts;
-      this._elements.healthBar?.render();
       if (this._stats.hp <= 0) {
         this._stats.hp = 0;
-        this._elements.healthBar?.render();
         console.log(`${this._name} has perished.`);
         this.fsm?.die()
         return;

--- a/js/classes/generateChest.js
+++ b/js/classes/generateChest.js
@@ -2,7 +2,7 @@ import { potions } from "../data/potions.js";
 import { armor } from "../data/armor.js";
 import { weapons } from "../data/weapons.js";
 import { itemTypes, generateItem } from "./generateItem.js";
-import buildElement from "../utils/buildElement.js";
+import {buildElement} from "../utils/webComponent.js";
 import dec from "../utils/decimalPlace.js";
 import Rand from "../utils/rng.js";
 import { UI } from "../utils/ui.js";

--- a/js/classes/generateEnemy.js
+++ b/js/classes/generateEnemy.js
@@ -1,7 +1,7 @@
 import Character from "./character.js";
 import { enemies } from "../data/enemies.js";
 import Rand from "../utils/rng.js";
-import buildElement from "../utils/buildElement.js";
+import {buildElement} from "../utils/webComponent.js";
 import dec from "../utils/decimalPlace.js";
 import generateStats from "../utils/generateStats.js";
 import mapRange from "../utils/valueMapper.js";
@@ -28,7 +28,7 @@ class Enemy extends Character {
       'health-bar',
       {class: 'health-bar'},
       {
-        stats: this._stats,
+        ...this._stats,
         maxHp: this._baseStats.hp
       }
     )

--- a/js/classes/player.js
+++ b/js/classes/player.js
@@ -1,5 +1,5 @@
 import Character from "./character.js";
-import buildElement from "../utils/buildElement.js";
+import { buildElement } from "../utils/webComponent.js";
 import mapRange from "../utils/valueMapper.js";
 import Rand from "../utils/rng.js";
 import { effectTypes, generateEffect } from "./generateEffect.js";
@@ -69,9 +69,15 @@ class Player extends Character {
     this._elements.healthBar = buildElement(
       'health-bar',
       {class: 'health-bar'},
-      {stats: this._stats,
-       maxHp: this._baseStats.hp}
+      {
+        ...this._stats,
+        maxHp: this._baseStats.hp
+      }
     );
+
+    this._elements.healthBar.render();
+    document.querySelector('#player-info').append(this._name)
+    document.querySelector('#player-info').appendChild(this._elements.healthBar);
 
     this.fsm = new FSM({
       transitions: [

--- a/js/components/action-button.js
+++ b/js/components/action-button.js
@@ -31,7 +31,6 @@ class ActionButton extends HTMLElement {
   connectedCallback() {
     //styles
     this.style.backgroundColor = colorCodes.gold
-    //this.render();
   }
 
 

--- a/js/components/health-bar.js
+++ b/js/components/health-bar.js
@@ -12,7 +12,7 @@ class HealthBar extends HTMLElement {
 
   render() {
     let maxWidth = UI.infoSection.getBoundingClientRect().width - 60;
-    let elWidth = mapRange(this.stats.hp, this.maxHp, 0, maxWidth, 0);
+    let elWidth = mapRange(this.hp, this.maxHp, 0, maxWidth, 0);
     this.style.width = `${elWidth}px`;
   }
 }

--- a/js/components/touch-icon.js
+++ b/js/components/touch-icon.js
@@ -1,8 +1,3 @@
-// import {UI} from '../utils/ui.js';
-
-// import buildElement from '../utils/buildElement.js';
-// import '../components/action-button.js';
-
 class TouchIcon extends HTMLElement {
   connectedCallback() {
     this.render();

--- a/js/utils/ui.js
+++ b/js/utils/ui.js
@@ -1,6 +1,6 @@
 // An object of all the UI components for easy access over document.querySelector
 
-import buildElement from "../utils/buildElement.js";
+import {buildElement} from "../utils/webComponent.js";
 
 export const UI = {
   infoSection: document.querySelector('#info-section'),

--- a/js/utils/webComponent.js
+++ b/js/utils/webComponent.js
@@ -9,7 +9,7 @@
   * 
   * YOU MUST HAVE THE COMPONENT JS FILE THAT GOES WITH IT
 */
-export default function buildElement(el, attrs = null, props = null) {
+function buildElement(el, attrs = null, props = null) {
   let element = document.createElement(el);
   if (attrs)
     for (let [attr, val] of Object.entries(attrs)) {
@@ -24,3 +24,14 @@ export default function buildElement(el, attrs = null, props = null) {
     
   return element;
 }
+
+function renderElements(p, val) {
+  Object.keys(this._elements).forEach(el => {
+    if(this._elements[el][p] && this._elements[el][p] !== val) {
+      this._elements[el][p] = val
+      this._elements[el].render();
+    }
+  });
+}
+
+export {buildElement, renderElements}

--- a/keith.js
+++ b/keith.js
@@ -74,5 +74,5 @@ import "./js/utils/ui.js";
 import Player from "./js/classes/player.js";
 import {enterNewRoom} from "./js/classes/enterRoom.js";
 
-let p = Player("Keith", {hp: 100, atk: 5, spd: 80, def: 0});
+let p = Player("Sir Rad-Cool III", {hp: 100, atk: 5, spd: 80, def: 0});
 enterNewRoom(p);


### PR DESCRIPTION
Wanted to push this up to demonstrate the use of a proxy in order to handle rendering web components when the object of the proxy changes value. This mimics the idea of rendering on props/state change. 

## Description

I've created a new export in buildElement file (known now as webComponent.js) that runs the diff of the value that's changing in any component that is using said value.

<details>
<summary>snippet of new function</summary>
<p>

```js
function renderElements(p, val) {
  Object.keys(this._elements).forEach(el => {
    if(this._elements[el][p] && this._elements[el][p] !== val) {
      this._elements[el][p] = val
      this._elements[el].render();
    }
  });
}
```
</p>
</details>  

At the class level, you create a proxy around the object containing the values you want to track. 

<details>
<summary>what it looks like in character class constructor</summary>
<p>

```js
constructor(name, stats) {

...

  this._stats = new Proxy(stats, {
    set: (target, prop, val) => {
      this.renderElements(prop, val)
      return Reflect.set(target, prop, val)  
    }
  });
}
```
</p>
</details>  

## Details
The [webComponent.js](https://github.com/heykc/READMEDungeon/pull/45/files#diff-fc963f55684fa4e3b2bd02fe41078d04) and [character.js](https://github.com/heykc/READMEDungeon/pull/45/files#diff-57bc895fd1f5628518cf49cc5cc974eb) files are the main files with the implemented features.
